### PR TITLE
Do not validate items that conflict

### DIFF
--- a/.changelog/24202.txt
+++ b/.changelog/24202.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack_set: Prevent validation of conflicting parameters in `operation_preferences`.
+```

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -322,14 +322,12 @@ func expandCloudFormationOperationPreferences(tfMap map[string]interface{}) *clo
 
 	if v, ok := tfMap["failure_tolerance_count"].(int); ok {
 		apiObject.FailureToleranceCount = aws.Int64(int64(v))
-	}
-	if v, ok := tfMap["failure_tolerance_percentage"].(int); ok {
+	} else if v, ok := tfMap["failure_tolerance_percentage"].(int); ok {
 		apiObject.FailureTolerancePercentage = aws.Int64(int64(v))
 	}
 	if v, ok := tfMap["max_concurrent_count"].(int); ok {
 		apiObject.MaxConcurrentCount = aws.Int64(int64(v))
-	}
-	if v, ok := tfMap["max_concurrent_percentage"].(int); ok {
+	} else if v, ok := tfMap["max_concurrent_percentage"].(int); ok {
 		apiObject.MaxConcurrentPercentage = aws.Int64(int64(v))
 	}
 	if v, ok := tfMap["region_concurrency_type"].(string); ok && v != "" {


### PR DESCRIPTION
The `failure_tolerance_count` and `failure_tolerance_percentage` conflict with each other so one should be validated only if the other has failed. The same applies for `max_concurrent_count` and `max_concurrent_percentage`